### PR TITLE
Allow multiple attachments in messages

### DIFF
--- a/src/Noobot.Core/MessagingPipeline/Request/IncomingMessage.cs
+++ b/src/Noobot.Core/MessagingPipeline/Request/IncomingMessage.cs
@@ -1,4 +1,5 @@
 ﻿using Noobot.Core.MessagingPipeline.Response;
+using System.Collections.Generic;
 
 namespace Noobot.Core.MessagingPipeline.Request
 {
@@ -70,7 +71,19 @@ namespace Noobot.Core.MessagingPipeline.Request
         /// </summary>
         public ResponseMessage ReplyToChannel(string text, Attachment attachment = null)
         {
-            return ResponseMessage.ChannelMessage(Channel, text, attachment);
+            if (attachment == null)
+                return ResponseMessage.ChannelMessage(Channel, text, attachments: null);
+    
+             var attachments = new List<Attachment> { attachment };
+             return ReplyToChannel(text, attachments);
+        }
+        
+        /// <summary>
+        /// Will generate a message to be sent the current channel the message arrived from
+        /// </summary>
+        public ResponseMessage ReplyToChannel(string text, List<Attachment> attachments)
+        {
+            return ResponseMessage.ChannelMessage(Channel, text, attachments);
         }
 
         /// <summary>
@@ -86,7 +99,7 @@ namespace Noobot.Core.MessagingPipeline.Request
         /// </summary>
         public ResponseMessage IndicateTypingOnChannel()
         {
-            return ResponseMessage.ChannelMessage(Channel, string.Empty, null, new TypingIndicatorMessage());
+            return ResponseMessage.ChannelMessage(Channel, string.Empty, attachments: null, message: new TypingIndicatorMessage());
         }
 
         /// <summary>

--- a/src/Noobot.Core/MessagingPipeline/Response/ResponseMessage.cs
+++ b/src/Noobot.Core/MessagingPipeline/Response/ResponseMessage.cs
@@ -1,4 +1,6 @@
-﻿namespace Noobot.Core.MessagingPipeline.Response
+﻿using System.Collections.Generic;
+
+namespace Noobot.Core.MessagingPipeline.Response
 {
     public class ResponseMessage
     {
@@ -6,7 +8,7 @@
         public string Channel { get; set; }
         public string UserId { get; set; }
         public ResponseType ResponseType { get; set; }
-        public Attachment Attachment { get; set; }
+        public List<Attachment> Attachments { get; set; }
 
         public static ResponseMessage DirectUserMessage(string userId, string text, ResponseMessage message = null)
         {
@@ -28,13 +30,22 @@
 
         public static ResponseMessage ChannelMessage(string channel, string text, Attachment attachment, ResponseMessage message = null)
         {
+            List<Attachment> attachments = null;
+            if (attachment != null)
+                attachments = new List<Attachment> { attachment };
+
+            return ChannelMessage(channel, text, attachments, message);
+        }
+
+        public static ResponseMessage ChannelMessage(string channel, string text, List<Attachment> attachments, ResponseMessage message = null)
+        {
             if (message == null)
                 message = new ResponseMessage();
 
             message.Channel = channel;
             message.ResponseType = ResponseType.Channel;
             message.Text = text;
-            message.Attachment = attachment;
+            message.Attachments = attachments;
 
             return message;
         }

--- a/src/Noobot.Core/NoobotCore.cs
+++ b/src/Noobot.Core/NoobotCore.cs
@@ -168,7 +168,7 @@ namespace Noobot.Core
                     {
                         ChatHub = chatHub,
                         Text = responseMessage.Text,
-                        Attachments = GetAttachments(responseMessage.Attachment)
+                        Attachments = GetAttachments(responseMessage.Attachments)
                     };
 
                     string textTrimmed = botMessage.Text.Length > 50 ? botMessage.Text.Substring(0, 50) + "..." : botMessage.Text;
@@ -182,26 +182,29 @@ namespace Noobot.Core
             }
         }
 
-        private IList<SlackAttachment> GetAttachments(Attachment attachment)
+        private IList<SlackAttachment> GetAttachments(List<Attachment> attachments)
         {
-            var attachments = new List<SlackAttachment>();
+            var slackAttachments = new List<SlackAttachment>();
 
-            if (attachment != null)
+            if (attachments != null)
             {
-                attachments.Add(new SlackAttachment
+                foreach (var attachment in attachments)
                 {
-                    Text = attachment.Text,
-                    Title = attachment.Title,
-                    Fallback = attachment.Fallback,
-                    ImageUrl = attachment.ImageUrl,
-                    ThumbUrl = attachment.ThumbUrl,
-                    AuthorName = attachment.AuthorName,
-                    ColorHex = attachment.Color,
-                    Fields = GetAttachmentFields(attachment)
-                });
+                    slackAttachments.Add(new SlackAttachment
+                    {
+                        Text = attachment.Text,
+                        Title = attachment.Title,
+                        Fallback = attachment.Fallback,
+                        ImageUrl = attachment.ImageUrl,
+                        ThumbUrl = attachment.ThumbUrl,
+                        AuthorName = attachment.AuthorName,
+                        ColorHex = attachment.Color,
+                        Fields = GetAttachmentFields(attachment)
+                    });
+                }
             }
 
-            return attachments;
+            return slackAttachments;
         }
 
         private IList<SlackAttachmentField> GetAttachmentFields(Attachment attachment)


### PR DESCRIPTION
Added the ability to return multiple attachments in ResponseMessage. The ResponseMessage Attachment property was changed to a list and name changed, otherwise extended classes to allow both a single Attachment and a list of Attachments.