### PR TITLE
Add properties to allow you to turn off all provided middleware

### DIFF
--- a/src/Noobot.Core/Configuration/IConfigReader.cs
+++ b/src/Noobot.Core/Configuration/IConfigReader.cs
@@ -13,7 +13,17 @@
         /// <summary>
         /// Should the "help" middleware be used?
         /// </summary>
-        bool HelpEnabled();
+        bool HelpEnabled { get; }
+
+        /// <summary>
+        /// Should the "stats" middleware be used?
+        /// </summary>
+        bool StatsEnabled { get; }
+
+        /// <summary>
+        /// Should the "about" middleware be used?
+        /// </summary>
+        bool AboutEnabled { get; }
 
         /// <summary>
         /// Should return any other configuration values you need within your middleware/plugins.

--- a/src/Noobot.Core/DependencyResolution/ContainerFactory.cs
+++ b/src/Noobot.Core/DependencyResolution/ContainerFactory.cs
@@ -2,14 +2,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-
 using Common.Logging;
-
 using Noobot.Core.Configuration;
 using Noobot.Core.MessagingPipeline.Middleware;
 using Noobot.Core.MessagingPipeline.Middleware.StandardMiddleware;
 using Noobot.Core.Plugins.StandardPlugins;
-
 using StructureMap;
 using StructureMap.Pipeline;
 

--- a/src/Noobot.Runner/Configuration/ConfigReader.cs
+++ b/src/Noobot.Runner/Configuration/ConfigReader.cs
@@ -14,10 +14,9 @@ namespace Noobot.Runner.Configuration
             return jObject.Value<string>("slack:apiToken");
         }
 
-        public bool HelpEnabled()
-        {
-            return true;
-        }
+        public bool StatsEnabled { get; } = true;
+        public bool AboutEnabled { get; } = true;
+        public bool HelpEnabled { get; } = true;
 
         public T GetConfigEntry<T>(string entryName)
         {


### PR DESCRIPTION
Following on from #65 - I've added two new properties to the `IConfigReader` interface and updated the `ContainerFactory` to support them. (I also changed the existing function into a property).

This allows us to turn off the default `stats` command, or replace the `about` command with my own, for example.

PS: Sorry for the number of changes in the `ContainerFactory`; my Visual Studio cleanup-on-save setting updated some of the formatting. Let me know if you need me to revert it.