### PR TITLE
Update UnhandledMessageMiddleware to always reply to Direct Messages

### DIFF
--- a/src/Noobot.Core/MessagingPipeline/Middleware/StandardMiddleware/UnhandledMessageMiddleware.cs
+++ b/src/Noobot.Core/MessagingPipeline/Middleware/StandardMiddleware/UnhandledMessageMiddleware.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading;
+﻿using System.Collections.Generic;
 
 using Common.Logging;
 using Noobot.Core.MessagingPipeline.Request;

--- a/src/Noobot.Core/MessagingPipeline/Middleware/StandardMiddleware/UnhandledMessageMiddleware.cs
+++ b/src/Noobot.Core/MessagingPipeline/Middleware/StandardMiddleware/UnhandledMessageMiddleware.cs
@@ -1,4 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+
 using Common.Logging;
 using Noobot.Core.MessagingPipeline.Request;
 using Noobot.Core.MessagingPipeline.Response;
@@ -19,13 +24,15 @@ namespace Noobot.Core.MessagingPipeline.Middleware.StandardMiddleware
 
         public IEnumerable<ResponseMessage> Invoke(IncomingMessage message)
         {
-            _log.Info("Unhandled");
-            return new ResponseMessage[0];
+            _log.Info("Unhandled message.");
+
+            if(message.ChannelType == ResponseType.DirectMessage)
+            {
+                yield return message.ReplyToChannel("Sorry, I didn't understand that request.");
+                yield return message.ReplyToChannel("Just type `help` so I can show you what I can do!");
+            }
         }
 
-        public IEnumerable<CommandDescription> GetSupportedCommands()
-        {
-            return new CommandDescription[0];
-        }
+        public IEnumerable<CommandDescription> GetSupportedCommands() => new CommandDescription[0];
     }
 }


### PR DESCRIPTION
At the moment, if you're having a DM with the bot and it doesn't understand, it'll just stay silent.
This is good if you're in a group channel (or group private chat), but not if you're experimenting or trying to configure the bot in a direct message.

I've updated the `UnhandledMessageMiddleware` to let the user know if it doesn't understand a Direct Message command and give the user some direction to help them understand what they can do (which should assist with on-boarding, etc.)