### PR TITLE
Update JokeMiddleware to replace Tambal joke

### DIFF
--- a/src/Noobot.Toolbox/Pipeline/Middleware/JokeMiddleware.cs
+++ b/src/Noobot.Toolbox/Pipeline/Middleware/JokeMiddleware.cs
@@ -1,15 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net;
-
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-
 using Noobot.Core.MessagingPipeline.Middleware;
 using Noobot.Core.MessagingPipeline.Request;
 using Noobot.Core.MessagingPipeline.Response;
 using Noobot.Core.Plugins.StandardPlugins;
-
 using RestSharp;
 
 namespace Noobot.Toolbox.Pipeline.Middleware


### PR DESCRIPTION
The URL for the Tambal joke didn't work any more and was causing the Middleware to crash.

Additionally, because the Chuck Norris joke comes back with a (slightly) different payload, I just quickly changed the way that we find the "joke" in the payload - pulling out the one `joke` property, building a JSON object and THEN deserialising it.

I also added the JsonProperty requirements so that the crash information will be a little more informative next time: `The 'joke' property was required, but not present.` (or something similar)