### PR TITLE
Update `ping list` to return a nicer message.

### DIFF
--- a/src/Noobot.Toolbox/Pipeline/Middleware/PingMiddleware.cs
+++ b/src/Noobot.Toolbox/Pipeline/Middleware/PingMiddleware.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
+
 using Noobot.Core.MessagingPipeline.Middleware;
 using Noobot.Core.MessagingPipeline.Request;
 using Noobot.Core.MessagingPipeline.Response;
@@ -59,8 +61,17 @@ namespace Noobot.Toolbox.Pipeline.Middleware
         {
             string[] users = _pingPlugin.ListPingedUsers();
 
-            yield return message.ReplyDirectlyToUser("I am currently pinging:");
-            yield return message.ReplyDirectlyToUser(">>>" + string.Join("\n", users));
-        }
+            if(users.Any())
+            {
+                yield return message.ReplyDirectlyToUser("I am currently pinging:");
+                yield return message.ReplyDirectlyToUser(">>>" + string.Join("\n", users));
+            }
+            else
+            {
+                yield return message.ReplyDirectlyToUser("I am not currently pinging anyone.");
+            }
+            
+
+    }
     }
 }

--- a/src/Noobot.Toolbox/Pipeline/Middleware/PingMiddleware.cs
+++ b/src/Noobot.Toolbox/Pipeline/Middleware/PingMiddleware.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-
 using Noobot.Core.MessagingPipeline.Middleware;
 using Noobot.Core.MessagingPipeline.Request;
 using Noobot.Core.MessagingPipeline.Response;


### PR DESCRIPTION
At the moment, the `ping list` command will return an empty block if there aren't any pings in process. 
This middleware now checks if there are some in progress, and if not, returns a nicer message.