### PR TITLE
Hide Middleware from `help` that doesn't have a handle.

### DIFF
--- a/src/Noobot.Toolbox/Pipeline/Middleware/AutoResponderMiddleware.cs
+++ b/src/Noobot.Toolbox/Pipeline/Middleware/AutoResponderMiddleware.cs
@@ -13,11 +13,12 @@ namespace Noobot.Toolbox.Pipeline.Middleware
             {
                 new HandlerMapping
                 {
-                    ValidHandles = new [] { ""},
+                    ValidHandles = new [] { "" },
                     Description = "Annoys the heck out of everyone",
                     EvaluatorFunc = AutoResponseHandler,
                     MessageShouldTargetBot = false,
-                    ShouldContinueProcessing = true
+                    ShouldContinueProcessing = true,
+                    VisibleInHelp = false
                 }
             };
         }

--- a/src/Noobot.Toolbox/Pipeline/Middleware/CalculatorMiddleware.cs
+++ b/src/Noobot.Toolbox/Pipeline/Middleware/CalculatorMiddleware.cs
@@ -31,7 +31,8 @@ namespace Noobot.Toolbox.Pipeline.Middleware
                     Description = "Try to calculate mathematical expressions without the 'calc' prefix - usage: ((1+2)*3)/4",
                     EvaluatorFunc = CalculateHandler,
                     MessageShouldTargetBot = false,
-                    ShouldContinueProcessing = true
+                    ShouldContinueProcessing = true,
+                    VisibleInHelp = false
                 }
             };
         }


### PR DESCRIPTION
At the moment, asking for `help` with these two middlewares enabled produces a list that contains empty "keywords", which is confusing. 

For now, it's probably better to hide these ones that are just always listening, and can't be directly activated.