### PR TITLE
Update `Noobot.Toolbox` to target 4.6

### DIFF
--- a/src/Noobot.Toolbox/Noobot.Toolbox.csproj
+++ b/src/Noobot.Toolbox/Noobot.Toolbox.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Noobot.Toolbox</RootNamespace>
     <AssemblyName>Noobot.Toolbox</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -64,11 +64,11 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\RestSharp.105.2.3\lib\net451\RestSharp.dll</HintPath>
+      <HintPath>..\..\packages\RestSharp.105.2.3\lib\net46\RestSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="SlackConnector, Version=3.0.6151.35275, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SlackConnector.3.0.6151.35275\lib\net45\SlackConnector.dll</HintPath>
+    <Reference Include="SlackConnector, Version=3.1.151.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SlackConnector.3.1.151\lib\net46\SlackConnector.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -112,7 +112,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Noobot.Toolbox/app.config
+++ b/src/Noobot.Toolbox/app.config
@@ -8,4 +8,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1" /></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" /></startup></configuration>

--- a/src/Noobot.Toolbox/packages.config
+++ b/src/Noobot.Toolbox/packages.config
@@ -8,8 +8,8 @@
   <package id="FlatFile.Delimited.Attributes" version="0.2.16" targetFramework="net451" />
   <package id="FlickrNet" version="3.17.0" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
-  <package id="RestSharp" version="105.2.3" targetFramework="net451" />
-  <package id="SlackConnector" version="3.0.6151.35275" targetFramework="net451" />
+  <package id="RestSharp" version="105.2.3" targetFramework="net46" />
+  <package id="SlackConnector" version="3.1.151" targetFramework="net46" />
   <package id="websocket-sharp-with-proxy-support" version="1.9.1" targetFramework="net451" />
   <package id="xFunc.Maths" version="2.15.16" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
At the moment, for whatever reason, the `Noobot.Toolbox` got left behind at .Net 4.5.1. This can cause some issues when running tests that include RestSharp, so we should bring them into line.

I know that in issue #60 you mentioned that you're moving away from RestSharp, but this small upgrade for this one project will prevent build/test issues for the mean-while.