### PR TITLE
User lookup by email

### DIFF
--- a/src/Noobot.Console/Noobot.Console.csproj
+++ b/src/Noobot.Console/Noobot.Console.csproj
@@ -15,6 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="Configuration\config.default.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="Configuration\config.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/src/Noobot.Core/Extensions.cs
+++ b/src/Noobot.Core/Extensions.cs
@@ -1,0 +1,19 @@
+﻿using SlackConnector.Models;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Noobot.Core
+{
+    public static class Extensions
+    {
+        public static IReadOnlyDictionary<string, SlackUser> WithEmailSet(this IReadOnlyDictionary<string, SlackUser> userCache) => 
+            new ReadOnlyDictionary<string, SlackUser>(userCache.Where(x => x.Value.Email != null).ToDictionary(z => z.Key, z => z.Value));
+
+        public static SlackUser FindByEmail(this IReadOnlyDictionary<string, SlackUser> userCache, string email) =>
+            userCache.Where(x => x.Value.Email != null).FirstOrDefault(x => x.Value.Email.Equals(email, StringComparison.OrdinalIgnoreCase)).Value;
+    }
+}

--- a/src/Noobot.Core/INoobotCore.cs
+++ b/src/Noobot.Core/INoobotCore.cs
@@ -10,7 +10,7 @@ namespace Noobot.Core
         Task Connect();
         void Disconnect();
         Task MessageReceived(SlackMessage message);
-        Task<SlackChatHub> SendMessage(ResponseMessage responseMessage);
+        Task SendMessage(ResponseMessage responseMessage);
         string GetUserIdForUsername(string username);
         string GetUserIdForUserEmail(string email);
         string GetChannelId(string channelName);

--- a/src/Noobot.Core/INoobotCore.cs
+++ b/src/Noobot.Core/INoobotCore.cs
@@ -10,7 +10,7 @@ namespace Noobot.Core
         Task Connect();
         void Disconnect();
         Task MessageReceived(SlackMessage message);
-        Task SendMessage(ResponseMessage responseMessage);
+        Task<SlackChatHub> SendMessage(ResponseMessage responseMessage);
         string GetUserIdForUsername(string username);
         string GetUserIdForUserEmail(string email);
         string GetChannelId(string channelName);

--- a/src/Noobot.Core/INoobotCore.cs
+++ b/src/Noobot.Core/INoobotCore.cs
@@ -12,6 +12,7 @@ namespace Noobot.Core
         Task MessageReceived(SlackMessage message);
         Task SendMessage(ResponseMessage responseMessage);
         string GetUserIdForUsername(string username);
+        string GetUserIdForUserEmail(string email);
         string GetChannelId(string channelName);
         string GetBotUserName();
         Dictionary<string, string> ListChannels();

--- a/src/Noobot.Core/NoobotCore.cs
+++ b/src/Noobot.Core/NoobotCore.cs
@@ -170,7 +170,7 @@ namespace Noobot.Core
             await _connection.Ping();
         }
 
-        public async Task SendMessage(ResponseMessage responseMessage)
+        public async Task<SlackChatHub> SendMessage(ResponseMessage responseMessage)
         {
             SlackChatHub chatHub = await GetChatHub(responseMessage);
 
@@ -199,6 +199,8 @@ namespace Noobot.Core
             {
                 _log.Error($"Unable to find channel for message '{responseMessage.Text}'. Message not sent");
             }
+
+            return chatHub;
         }
 
         private IList<SlackAttachment> GetAttachments(List<Attachment> attachments)
@@ -254,7 +256,7 @@ namespace Noobot.Core
 
         public string GetUserIdForUserEmail(string email)
         {
-            var user = _connection.UserCache.FirstOrDefault(x => x.Value.Email.Equals(email, StringComparison.OrdinalIgnoreCase));
+            var user = _connection.UserCache.Where(x => x.Value.Email != null).FirstOrDefault(x => x.Value.Email.Equals(email, StringComparison.OrdinalIgnoreCase));
             return string.IsNullOrEmpty(user.Key) ? string.Empty : user.Key;
         }
 

--- a/src/Noobot.Core/NoobotCore.cs
+++ b/src/Noobot.Core/NoobotCore.cs
@@ -252,6 +252,12 @@ namespace Noobot.Core
             return string.IsNullOrEmpty(user.Key) ? string.Empty : user.Key;
         }
 
+        public string GetUserIdForUserEmail(string email)
+        {
+            var user = _connection.UserCache.FirstOrDefault(x => x.Value.Email.Equals(email, StringComparison.OrdinalIgnoreCase));
+            return string.IsNullOrEmpty(user.Key) ? string.Empty : user.Key;
+        }
+
         public string GetChannelId(string channelName)
         {
             var channel = _connection.ConnectedChannels().FirstOrDefault(x => x.Name.Equals(channelName, StringComparison.OrdinalIgnoreCase));

--- a/src/Noobot.Core/NoobotCore.cs
+++ b/src/Noobot.Core/NoobotCore.cs
@@ -254,7 +254,7 @@ namespace Noobot.Core
 
         public string GetUserIdForUserEmail(string email)
         {
-            var user = _connection.UserCache.FirstOrDefault(x => x.Value.Email.Equals(email, StringComparison.OrdinalIgnoreCase));
+            var user = _connection.UserCache.Where(x => x.Value.Email != null).FirstOrDefault(x => x.Value.Email.Equals(email, StringComparison.OrdinalIgnoreCase));
             return string.IsNullOrEmpty(user.Key) ? string.Empty : user.Key;
         }
 

--- a/src/Noobot.Core/NoobotCore.cs
+++ b/src/Noobot.Core/NoobotCore.cs
@@ -170,7 +170,7 @@ namespace Noobot.Core
             await _connection.Ping();
         }
 
-        public async Task<SlackChatHub> SendMessage(ResponseMessage responseMessage)
+        public async Task SendMessage(ResponseMessage responseMessage)
         {
             SlackChatHub chatHub = await GetChatHub(responseMessage);
 
@@ -199,8 +199,6 @@ namespace Noobot.Core
             {
                 _log.Error($"Unable to find channel for message '{responseMessage.Text}'. Message not sent");
             }
-
-            return chatHub;
         }
 
         private IList<SlackAttachment> GetAttachments(List<Attachment> attachments)
@@ -256,7 +254,7 @@ namespace Noobot.Core
 
         public string GetUserIdForUserEmail(string email)
         {
-            var user = _connection.UserCache.Where(x => x.Value.Email != null).FirstOrDefault(x => x.Value.Email.Equals(email, StringComparison.OrdinalIgnoreCase));
+            var user = _connection.UserCache.FirstOrDefault(x => x.Value.Email.Equals(email, StringComparison.OrdinalIgnoreCase));
             return string.IsNullOrEmpty(user.Key) ? string.Empty : user.Key;
         }
 

--- a/src/Noobot.Core/NoobotCore.cs
+++ b/src/Noobot.Core/NoobotCore.cs
@@ -48,6 +48,7 @@ namespace Noobot.Core
             _log.Info("Connected!");
             _log.Info($"Bots Name: {_connection.Self.Name}");
             _log.Info($"Team Name: {_connection.Team.Name}");
+            _log.Info($"Id for user: {GetUserIdForUserEmail("zimny.jot@gmail.com")}");
 
             _container.GetPlugin<StatsPlugin>()?.RecordStat("Connected:Since", DateTime.Now.ToString("G"));
             _container.GetPlugin<StatsPlugin>()?.RecordStat("Response:Average", _averageResponse);
@@ -254,8 +255,8 @@ namespace Noobot.Core
 
         public string GetUserIdForUserEmail(string email)
         {
-            var user = _connection.UserCache.Where(x => x.Value.Email != null).FirstOrDefault(x => x.Value.Email.Equals(email, StringComparison.OrdinalIgnoreCase));
-            return string.IsNullOrEmpty(user.Key) ? string.Empty : user.Key;
+            var user = _connection.UserCache.WithEmailSet().FindByEmail(email);
+            return user?.Id ?? string.Empty;
         }
 
         public string GetChannelId(string channelName)

--- a/tests/Noobot.Tests.Unit/Core/Slack/ExtensionsTests.cs
+++ b/tests/Noobot.Tests.Unit/Core/Slack/ExtensionsTests.cs
@@ -1,0 +1,143 @@
+﻿using Moq;
+using SlackConnector.Models;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Noobot.Core;
+using Shouldly;
+
+namespace Noobot.Tests.Unit.Core.Slack
+{
+    public class ExtensionsTests
+    {
+        
+        [Fact]
+        public void FindByEmail_WithEmailSetExtension_ReturnsOnlyRecordsWithEmailSet()
+        {
+            //Arrange
+            var slackUser = new SlackUser()
+            {
+                Id = "ABC",
+                Email = "john.doe@microsoft.com"
+            };
+
+            var userCache = new ReadOnlyDictionary<string, SlackUser>(new Dictionary<string, SlackUser>
+            {
+                { slackUser.Id, slackUser }
+            });
+
+
+            //Act
+            var result = userCache.WithEmailSet();
+
+            //Assert
+            result.First().Value.Email.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void FindByEmail_WithoutEmailSet_DoesNotReturnUser()
+        {
+            //Arrange
+            var slackUser = new SlackUser()
+            {
+                Id = "ABC",
+            };
+
+            var userCache = new ReadOnlyDictionary<string, SlackUser>(new Dictionary<string, SlackUser>
+            {
+                { slackUser.Id, slackUser }
+            });
+
+
+            //Act
+            var result = userCache.WithEmailSet();
+
+            //Assert
+            result.ShouldBeEmpty();
+        }
+
+        [Fact]
+        public void GetUserIdForEmail_WithEmailSet_ReturnsId()
+        {
+            //Arrange
+            var slackUser = new SlackUser()
+            {
+                Id = "ABC",
+                Email = "john.doe@microsoft.com"
+            };
+
+            var userCache = new ReadOnlyDictionary<string, SlackUser>(new Dictionary<string, SlackUser>
+            {
+                { slackUser.Id, slackUser }
+            });
+
+
+            //Act
+            var result = userCache.FindByEmail("john.doe@microsoft.com");
+
+            //Assert
+            result.Id.ShouldBe("ABC");
+        }
+
+        [Fact]
+        public void GetUserIdForEmail_WithoutEmailSet_ReturnsNull()
+        {
+            //Arrange
+            var slackUser = new SlackUser()
+            {
+                Id = "ABC"
+            };
+
+            var userCache = new ReadOnlyDictionary<string, SlackUser>(new Dictionary<string, SlackUser>
+            {
+                { slackUser.Id, slackUser }
+            });
+
+
+            //Act
+            var result = userCache.FindByEmail("john.doe@microsoft.com");
+
+            //Assert
+            result.ShouldBeNull();
+        }
+
+        [Fact]
+        public void GetUserIdForEmail_MultipleUsersWithEmailSet_ReturnsCorrectUser()
+        {
+            //Arrange
+            var slackUser1 = new SlackUser()
+            {
+                Id = "ABC",
+                Email = "john.doe@microsoft.com"
+            };
+            var slackUser2 = new SlackUser()
+            {
+                Id = "DEF",
+                Email = "john.doe@gmail.com"
+            };
+            var slackUser3 = new SlackUser()
+            {
+                Id = "QWE",
+                Email = "john.doe@yahoo.com"
+            };
+
+            var userCache = new ReadOnlyDictionary<string, SlackUser>(new Dictionary<string, SlackUser>
+            {
+                { slackUser1.Id, slackUser1 },
+                { slackUser2.Id, slackUser2 },
+                { slackUser3.Id, slackUser3 },
+            });
+
+
+            //Act
+            var result = userCache.FindByEmail("john.doe@microsoft.com");
+
+            //Assert
+            result.Id.ShouldBe("ABC");
+        }
+    }
+}

--- a/tests/Noobot.Tests.Unit/Noobot.Tests.Unit.csproj
+++ b/tests/Noobot.Tests.Unit/Noobot.Tests.Unit.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="expectedobjects" Version="2.3.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="shouldly" Version="2.8.3" />
     <PackageReference Include="SlackConnector" Version="4.1.29" />
     <PackageReference Include="xunit" Version="2.2.0" />
@@ -21,7 +22,7 @@
 
   <ItemGroup>
     <None Update="Configuration\config.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 


### PR DESCRIPTION
In our project we match users based on their emails in slack enterprise grid and other external systems.
We needed functionality to find slack user id by email, so that we could message people directly based on their email address.