### PR TITLE
Allow specification of external configuration path

### DIFF
--- a/src/Noobot.Core/Configuration/JsonConfigReader.cs
+++ b/src/Noobot.Core/Configuration/JsonConfigReader.cs
@@ -10,13 +10,15 @@ namespace Noobot.Core.Configuration
         private JObject _currentJObject;
         private readonly string _configLocation;
         private readonly object _lock = new object();
+        private static bool _externalConfigPath = false;
         private static readonly string DEFAULT_LOCATION = Path.Combine("configuration", "config.json");
         private const string SLACKAPI_CONFIGVALUE = "slack:apiToken";
 
-        public JsonConfigReader() : this(DEFAULT_LOCATION) { }
-        public JsonConfigReader(string configurationFile)
+        public JsonConfigReader() : this(DEFAULT_LOCATION, true) { }
+        public JsonConfigReader(string configurationFile, bool isDefault = false)
         {
             _configLocation = configurationFile;
+            _externalConfigPath = !isDefault;
         }
 
         public bool HelpEnabled { get; set; } = true;
@@ -36,8 +38,7 @@ namespace Noobot.Core.Configuration
             {
                 if (_currentJObject == null)
                 {
-                    string assemblyLocation = AssemblyLocation();
-                    string fileName = Path.Combine(assemblyLocation, _configLocation);
+                    string fileName = _externalConfigPath ? _configLocation : Path.Combine(AssemblyLocation(), _configLocation);
                     string json = File.ReadAllText(fileName);
                     _currentJObject = JObject.Parse(json);
                 }


### PR DESCRIPTION
The current algorithm which decides where to look for the `config.json` file only looks within the 'configuration' directory of the directory where 'Noobot.Core' resides due to the call to `Path.Combine()` being based on the result of `AssemblyLocation()`.  This is okay when you have the source included in your project, but when installed as a nuget package it doesn't go so smoothly.  Therefore I've added functionality to `JsonConfigReader.cs` for the path to `config.json` to be specified in the constructor.  This allows you to name the JSON config file anything you like as well as place it anywhere you choose.  See example constructor call in the sample code below:

```
var containerFactory = new ContainerFactory(
    new ConfigurationBase(),
    new JsonConfigReader(@"DirWhereMyConfigFileLives\myrandomconfigfilename.json"),
    GetLogger());
```

After my modifications, calling the `JsonConfigReader` constructor with no arguments (as originally designed) defaults back to the original functionality.