### PR TITLE
Json reader can be constructed with different paths

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 3.1.{build}
+version: 3.2.{build}
 skip_tags: true
 image: Visual Studio 2017
 configuration: Release

--- a/src/Noobot.Console/Program.cs
+++ b/src/Noobot.Console/Program.cs
@@ -31,7 +31,7 @@ namespace Noobot.Console
         {
             var containerFactory = new ContainerFactory(
                 new ConfigurationBase(),
-                new JsonConfigReader(),
+                JsonConfigReader.DefaultLocation(),
                 GetLogger());
 
             INoobotContainer container = containerFactory.CreateContainer();

--- a/tests/Noobot.Tests.Unit/Core/Configuration/JsonConfigReaderTests.cs
+++ b/tests/Noobot.Tests.Unit/Core/Configuration/JsonConfigReaderTests.cs
@@ -10,7 +10,7 @@ namespace Noobot.Tests.Unit.Core.Configuration
         public void should_read_config()
         {
             // given
-            var reader = new JsonConfigReader();
+            var reader = JsonConfigReader.DefaultLocation();
 
             // when
             string slackKey = reader.SlackApiKey;

--- a/tests/Noobot.Tests.Unit/Core/Slack/SlackConnectorTests.cs
+++ b/tests/Noobot.Tests.Unit/Core/Slack/SlackConnectorTests.cs
@@ -13,7 +13,7 @@ namespace Noobot.Tests.Unit.Core.Slack
         public async Task should_connect_as_expected()
         {
             // given
-            var configReader = new JsonConfigReader();
+            var configReader = JsonConfigReader.DefaultLocation();
             var containerStub = new NoobotContainerStub();
             var connector = new NoobotCore(configReader, new EmptyLogger(), containerStub);
 


### PR DESCRIPTION
Resolves #109 

Use the new helper methods to construct the JsonReader class

```csharp
var defaultReader = JsonConfigReader.DefaultLocation();
var absolutePathReader = JsonConfigReader.ForAbsolutePath("C:\\something.json");
var relativePathReader = JsonConfigReader.ForRelativePath("config\\somethingElse.json");
```